### PR TITLE
小米音乐开屏广告无法跳过

### DIFF
--- a/src/globalDefaultApps.ts
+++ b/src/globalDefaultApps.ts
@@ -87,4 +87,5 @@ export const commonAppBlackList: string[] = [
 
 export const systemAppWhiteList: string[] = [
   // 在一些系统软件中启用
+  'com.miui.player',  //小米音乐
 ];

--- a/src/globalDefaultApps.ts
+++ b/src/globalDefaultApps.ts
@@ -87,5 +87,5 @@ export const commonAppBlackList: string[] = [
 
 export const systemAppWhiteList: string[] = [
   // 在一些系统软件中启用
-  'com.miui.player',  //小米音乐
+  'com.miui.player', //小米音乐
 ];

--- a/src/globalDefaultApps.ts
+++ b/src/globalDefaultApps.ts
@@ -87,5 +87,4 @@ export const commonAppBlackList: string[] = [
 
 export const systemAppWhiteList: string[] = [
   // 在一些系统软件中启用
-  'com.miui.player', //小米音乐
 ];

--- a/src/globalGroups.ts
+++ b/src/globalGroups.ts
@@ -40,6 +40,7 @@ const openEnabledAppIds = new Set([
   'com.miui.systemAdSolution', // 小米智能服务
   'com.huawei.appmarket', // 华为应用市场
   'com.xiaomi.market', // 小米应用商店
+  'com.miui.player', //小米音乐
 ]);
 const updateEnabledAppIds = new Set([...systemAppWhiteList]);
 const youngEnabledAppIds = new Set([...systemAppWhiteList]);


### PR DESCRIPTION
小米音乐被当作系统应用，导致开屏广告默认关闭，请问是否可以这么改？
https://i.gkd.li/i/14783405
![861C8A1256C964D49863E8A7E07B9513](https://github.com/Adpro-Team/GKD_subscription/assets/74281356/30238a57-1aa1-4b27-bf6a-befbe1dc127e)
